### PR TITLE
add api endpoint for requesting city

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 var https = require("https");
 var express = require('express');
 var app = express();
@@ -25,6 +26,12 @@ app.get('/api/forcasts/', function(req, res){
     .catch(function(err){
       res.send(err);
     })
+})
+
+app.post('/api/forcast/', function(req, res) {
+  getForcast(req.body.lat, req.body.lng, function(data) {
+    res.send(data);
+  });
 })
 
 app.get('/api/populations/', function(req, res) {


### PR DESCRIPTION
There were two bugs related to the search dropdown functionality 
The post endpoint got removed (added it back)
The .env file holding the api keys for darkstar and amedaeus needed to be in the root from where npm start is ran.